### PR TITLE
Fix dialog interactions

### DIFF
--- a/api/src/main/java/org/rspeer/game/component/Dialog.java
+++ b/api/src/main/java/org/rspeer/game/component/Dialog.java
@@ -3,17 +3,16 @@ package org.rspeer.game.component;
 import jag.RSNodeTable;
 import jag.game.RSInterfaceComponent;
 import jag.game.RSSubInterface;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 import org.rspeer.commons.Time;
 import org.rspeer.game.Game;
 import org.rspeer.game.Keyboard;
 import org.rspeer.game.adapter.component.InterfaceComponent;
 import org.rspeer.game.query.component.ComponentQuery;
 import org.rspeer.game.query.results.ComponentQueryResults;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Predicate;
 
 public class Dialog {
 
@@ -162,6 +161,6 @@ public class Dialog {
             return new ComponentQuery(Collections::emptyList);
         }
 
-        return new ComponentQuery(container::getSubComponents);
+        return new ComponentQuery(container::getSubComponents).filter(c -> c.getForeground() == 0);
     }
 }


### PR DESCRIPTION
The query used to return the "Select an Option" header component which pushes the indices by 1 when trying to interact with a matching component

![Overwolf_ZcToIBdGH3](https://user-images.githubusercontent.com/12108656/87851473-61b6c000-c8f9-11ea-9922-ed3c839f91ca.png)